### PR TITLE
feat: publishing auto-clears the draft flag

### DIFF
--- a/.claude/commands/publish.md
+++ b/.claude/commands/publish.md
@@ -1,6 +1,6 @@
 ---
 description: Convert a vault draft to a site .qmd and ship it through the branch→PR→merge→deploy flow.
-argument-hint: <vault-draft-path> | --all [--force]
+argument-hint: <vault-draft-path> | --all
 allowed-tools: Bash, Read, AskUserQuestion
 ---
 
@@ -16,11 +16,15 @@ Do all of this from the repo root (`~/vault/projects/ChrisKornaros.github.io`).
 
 Run: `uv run publish $ARGUMENTS`
 
-- If it reports a file is still `draft: true`, stop and tell Chris to clear the
-  flag in the vault (or re-run with `--force`). Do **not** force on his behalf.
+- Publishing **is** the act of un-drafting: a single-file publish converts the
+  file regardless of its draft flag and clears `draft: true` from the vault
+  source (prints "un-drafted vault source"). `--all` still skips anything still
+  tagged `draft: true`.
 - On success it prints the `.qmd` (and any copied images / new category
   `index.qmd`) it wrote under `source/pages/`. Note the section + slug from the
   output — you need them for the branch name.
+- The vault `.md` edit is just the one-line draft removal; mention it but you do
+  not commit the vault (separate repo) — it stays as Chris's canonical source.
 
 ## 2. Render (verification + regenerates the tracked `docs/`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,9 @@ A draft is the canonical source; the site `.qmd` is generated from it.
   ([.claude/commands/publish.md](.claude/commands/publish.md)) runs the
   deterministic converter (`uv run publish <draft>` / `--all`), then
   `quarto render`, then the canonical session-end loop on a
-  `publish/<section>-<slug>` branch. Merge = deploy.
+  `publish/<section>-<slug>` branch. Merge = deploy. A single-file publish
+  **un-drafts the vault source** (clears `draft: true`); `--all` skips anything
+  still tagged draft.
 - **The converter** lives in [site_publish/](site_publish/) and does the
   transform only — never git. It maps Obsidian → Quarto (wikilinks, `![[embeds]]`
   → copied `images/`, callouts, strips `#tags`/`draft`), routes by section

--- a/site_publish/cli.py
+++ b/site_publish/cli.py
@@ -7,7 +7,7 @@ import datetime as _dt
 import sys
 from pathlib import Path
 
-from . import config, convert
+from . import config, convert, frontmatter_map
 from .convert import ConvertError
 from .frontmatter_map import FrontmatterError
 
@@ -38,7 +38,7 @@ def _iter_non_draft_drafts():
             meta = frontmatter.load(str(md)).metadata
         except Exception:
             continue
-        if not meta.get("draft"):
+        if not frontmatter_map.is_draft(meta):
             yield md
 
 
@@ -53,10 +53,6 @@ def publish(argv: list[str] | None = None) -> int:
         "--all", action="store_true",
         help="Convert every non-draft file under the vault writing root.",
     )
-    parser.add_argument(
-        "--force", action="store_true",
-        help="Publish even if the draft is still marked draft: true.",
-    )
     args = parser.parse_args(argv)
 
     if bool(args.file) == bool(args.all):
@@ -70,7 +66,7 @@ def publish(argv: list[str] | None = None) -> int:
     failures = 0
     for draft in drafts:
         try:
-            result = convert.convert(draft, force=args.force)
+            result = convert.convert(draft)
         except (ConvertError, FrontmatterError, ValueError) as exc:
             print(f"  ✗ {draft}: {exc}", file=sys.stderr)
             failures += 1
@@ -79,6 +75,8 @@ def publish(argv: list[str] | None = None) -> int:
         for extra in result.written:
             if extra != result.qmd_path:
                 print(f"      + {_rel(extra)}")
+        if convert.clear_source_draft(draft):
+            print("      (un-drafted vault source)")
 
     if failures:
         print(f"\n{failures} file(s) failed.", file=sys.stderr)

--- a/site_publish/convert.py
+++ b/site_publish/convert.py
@@ -7,6 +7,7 @@ touches git.
 
 from __future__ import annotations
 
+import re
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -60,12 +61,35 @@ def _ensure_category_index(target: routing.Target, result: Result) -> None:
     result.written.append(index)
 
 
+_FM_BLOCK = re.compile(r"\A---\r?\n.*?\r?\n---", re.DOTALL)
+_DRAFT_TRUE = re.compile(r"(?mi)^[ \t]*draft:[ \t]*true[ \t]*\r?\n")
+
+
+def clear_source_draft(draft: Path) -> bool:
+    """Remove a ``draft: true`` line from the vault source's frontmatter.
+
+    Publishing un-drafts the canonical source so future ``--all`` syncs include
+    it. Surgical line removal within the frontmatter block only (not a full
+    round-trip) to avoid churning the author's file formatting or touching the
+    body. Returns True if a change was made.
+    """
+    text = draft.read_text(encoding="utf-8")
+    m = _FM_BLOCK.match(text)
+    if not m:
+        return False
+    new_block, n = _DRAFT_TRUE.subn("", m.group(0))
+    if not n:
+        return False
+    draft.write_text(new_block + text[m.end():], encoding="utf-8")
+    return True
+
+
 def _dump_qmd(meta: dict, body: str) -> str:
     fm = yaml.safe_dump(meta, sort_keys=False, allow_unicode=True).rstrip("\n")
     return f"---\n{fm}\n---\n\n{body.strip()}\n"
 
 
-def convert(draft: Path, *, force: bool = False) -> Result:
+def convert(draft: Path) -> Result:
     draft = draft.resolve()
     if not draft.is_file():
         raise ConvertError(f"Draft not found: {draft}")
@@ -74,12 +98,10 @@ def convert(draft: Path, *, force: bool = False) -> Result:
     meta = dict(post.metadata)
     section = routing.section_for(draft)
 
-    if frontmatter_map.is_draft(meta) and not force:
-        raise ConvertError(
-            f"{draft.name} is still marked draft: true. Remove the flag or pass "
-            f"--force to publish anyway."
-        )
-
+    # Publishing is the act of un-drafting: the draft flag is stripped from the
+    # output here (see frontmatter_map._DROP_KEYS) and cleared from the vault
+    # source by the caller. An explicit publish always proceeds; --all decides
+    # what to touch via the draft flag before reaching this function.
     mapped = frontmatter_map.map_metadata(section, meta)
     target = routing.resolve(draft, title=str(mapped["title"]))
     result = Result(


### PR DESCRIPTION
## What

Publishing now **un-drafts** in one shot: a single-file `uv run publish` always converts and removes `draft: true` from the vault source. No more refusal gate / `--force`. Requested follow-up to the pipeline (PR #3).

## Why

Publishing *is* the act of un-drafting — handling it in one step matches the mental model and means `--all` naturally re-syncs the file afterward.

## Changes

- `convert.py`: drop the draft gate + `force` param; add `clear_source_draft()` — surgical removal of the `draft: true` line *within the frontmatter block only* (no full round-trip, body untouched).
- `cli.py`: clear the source after a successful publish (prints "un-drafted vault source"); remove `--force`; use `frontmatter_map.is_draft` in the `--all` scan.
- `.claude/commands/publish.md`, `CLAUDE.md`: document the behavior.

## Behavior

| Command | Draft file | Non-draft file |
|---|---|---|
| `publish <file>` | publishes + clears `draft: true` | publishes (no-op clear) |
| `publish --all` | **skipped** | publishes |

## Delivered + Verified

Dry-run in temp **and** the real vault: `new` → enrich → `publish` cleared `draft: true` while preserving `title`/`author`/`date`/`categories`/`video`; generated `.qmd` correct (YouTube embed, callout, wikilink→text, tags stripped); `quarto render` clean (0 fenced-div warnings for the doc in isolation). All throwaway artifacts removed — no content deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)