### PR TITLE
feat(publish): normalize Substack share URLs in the embed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,10 @@ A draft is the canonical source; the site `.qmd` is generated from it.
   transform only — never git. It maps Obsidian → Quarto (wikilinks, `![[embeds]]`
   → copied `images/`, callouts, strips `#tags`/`draft`), routes by section
   (recipes → `recipes/<Category>/`, others → `<section>/posts/`), generates the
-  Substack embed for blogs and the `video:` embed for recipes, and is
-  idempotent (re-publish overwrites the `.qmd`).
+  Substack embed for blogs (normalizing a "Share"-link `open.substack.com/pub/…`
+  URL with tracking params to the canonical `<pub>.substack.com/p/<slug>` form)
+  and the `video:` embed for recipes, and is idempotent (re-publish overwrites
+  the `.qmd`).
 - **No `_quarto.yml` edits per publish:** the navbar links to listing pages, the
   guides/blogs sidebars auto-list their `posts/` directory, and the recipes
   sidebar lists category index pages, so a newly published post appears

--- a/site_publish/embeds.py
+++ b/site_publish/embeds.py
@@ -10,10 +10,34 @@ import re
 from urllib.parse import parse_qs, urlparse
 
 _YT_ID = re.compile(r"^[A-Za-z0-9_-]{11}$")
+_SHARE_PATH = re.compile(r"^/pub/([^/]+)/p/(.+)$")
+
+
+def _canonical_substack_url(url: str) -> str:
+    """Normalize a Substack URL to the canonical post form for embedding.
+
+    Substack's "Share" button hands out a tracking link
+    (``open.substack.com/pub/<pub>/p/<slug>?r=...&utm_...``); ``embed.js`` wants
+    the canonical ``<pub>.substack.com/p/<slug>`` shape used in test.qmd. Rewrite
+    the share form and drop the query/fragment in every case. A URL already in
+    canonical form just loses its tracking params; an unrecognized URL is
+    returned untouched.
+    """
+    parsed = urlparse(url)
+    host = parsed.netloc.lower()
+    path = parsed.path.rstrip("/")
+    if host == "open.substack.com":
+        m = _SHARE_PATH.match(path)
+        if m:
+            return f"https://{m.group(1)}.substack.com/p/{m.group(2)}"
+    if host:
+        return f"{parsed.scheme or 'https'}://{host}{path}"
+    return url
 
 
 def substack_embed(title: str, url: str) -> str:
     """Substack post embed stub (verbatim shape of the existing test.qmd)."""
+    url = _canonical_substack_url(url)
     return (
         "```{=html}\n"
         f'<div class="substack-post-embed"><p lang="en">{title} by '


### PR DESCRIPTION
## What
Adds `_canonical_substack_url()` to `site_publish/embeds.py` so the blog converter normalizes the URL it puts in the Substack embed:
- rewrites the Share-link form `open.substack.com/pub/<pub>/p/<slug>` → canonical `<pub>.substack.com/p/<slug>`,
- strips `?r=...&utm_...` tracking query/fragment in all cases,
- already-canonical URLs are idempotent; unknown hosts pass through.

## Why
Substack's "Share" button gives a tracking URL, but `embed.js` expects the canonical post URL (the shape in `test.qmd`). Without this, publishing a blog required hand-cleaning the `substack:` frontmatter (which is what happened for the first post). Now a pasted Share link just works.

## Delivered + Verified
- **Delivered:** copied Substack Share links normalize automatically at publish time.
- **Verified:** functional check via `uv run python` over 5 cases (share link, canonical, canonical+utm, trailing slash, non-Substack) — all produce the expected canonical/clean output. No site re-render needed; the already-published `figuring-things-out.qmd` already carries the canonical URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)