### PR TITLE
feat(announce): Bluesky post automation for the publish flow

### DIFF
--- a/.claude/commands/announce.md
+++ b/.claude/commands/announce.md
@@ -1,0 +1,58 @@
+---
+description: Post a Bluesky announcement for a just-published post. Reads the app password from Bitwarden (bw) at run time.
+argument-hint: <vault-draft-path> [--url <link>] [--tag <t>] [--dry-run]
+allowed-tools: Bash, Read
+---
+
+You are running the **announce** step: post a short Bluesky update linking to a
+post that was *already published* via `/publish`. This is a runtime action, not
+a code change — it creates **no git branch, commit, or PR**. (The `announce`
+command itself was added to the repo in its own PR; running it just posts.)
+
+Arguments: `$ARGUMENTS` — a published vault draft path (supplies title + link),
+and/or `--url`, `--title`, `--tag`, `--text`, `--item`, `--dry-run`.
+
+Run everything from the repo root (`~/vault/projects/ChrisKornaros.github.io`).
+
+## 1. Compose and preview first — always dry-run
+
+Run: `uv run announce $ARGUMENTS --dry-run`
+
+- This composes the post and prints it plus the detected facets (clickable link
+  + any `#tags`). It does **not** touch Bitwarden or the network.
+- For a blog draft the link comes from the draft's `substack:` frontmatter; for
+  anything else pass `--url`. Override the headline with `--title`, the whole
+  text with `--text`, and add hashtags with `--tag` (lowercase, few).
+- Show Chris the composed post and confirm it reads right before sending.
+
+## 2. Make sure the Bitwarden vault is unlocked
+
+The send step reads the Bluesky **app password** (not the account password)
+from a Bitwarden item via the `bw` CLI. It needs an unlocked vault in the shell:
+
+```sh
+export BW_SESSION="$(bw unlock --raw)"
+```
+
+- Config (non-secret) is env-driven: `BLUESKY_BW_ITEM` (default `Bluesky`) names
+  the vault item; its username is the handle and its password is the app
+  password. `BLUESKY_HANDLE` overrides the identifier if needed.
+- Never print, echo, or log the password. If `bw` reports the vault is locked or
+  you're not logged in, surface that and stop — don't work around it.
+
+## 3. Send
+
+Run the same command **without** `--dry-run`:
+
+`uv run announce $ARGUMENTS`
+
+On success it prints the posting handle and the `bsky.app` URL of the new post.
+Report that URL back. On failure (locked vault, missing item, API error) it
+prints the reason and exits non-zero — relay it, don't retry blindly.
+
+## Notes
+
+- One post per publish; re-running posts again (the API has no dedupe).
+- Eventually this folds into `content_manager`'s multi-platform poster behind
+  its `core/secrets.py` Bitwarden boundary; the `bw`-CLI shape here is the
+  documented bridge until then.

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,11 @@ wheels/
 # Virtual environments
 .venv
 
+# Secrets -- read at run time from Bitwarden (bw), never committed.
+.env
+*.key
+*.pem
+
 # Local environments
 *.DS_Store
 *.vscode/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,6 +102,18 @@ A draft is the canonical source; the site `.qmd` is generated from it.
   URL with tracking params to the canonical `<pub>.substack.com/p/<slug>` form)
   and the `video:` embed for recipes, and is idempotent (re-publish overwrites
   the `.qmd`).
+- **Announce on Bluesky (optional, after publish):** the **`/announce`** skill
+  ([.claude/commands/announce.md](.claude/commands/announce.md)) posts a short
+  Bluesky update linking to a just-published post. `uv run announce <draft>
+  [--url …] [--tag …] --dry-run` composes + previews (clickable link/hashtag
+  facets, no network); dropping `--dry-run` sends it. It's a **runtime action,
+  not a code change** — no branch/PR. The Bluesky **app password** is read at
+  run time from a Bitwarden item via the `bw` CLI through the single
+  [site_publish/secrets.py](site_publish/secrets.py) boundary (unlock first:
+  `export BW_SESSION="$(bw unlock --raw)"`); it's never written to a file or
+  printed. Config is env-driven (`BLUESKY_BW_ITEM`, default `Bluesky`;
+  `BLUESKY_HANDLE` to override the identifier). Folds into `content_manager`'s
+  multi-platform poster later — the `bw`-CLI shape is the documented bridge.
 - **No `_quarto.yml` edits per publish:** the navbar links to listing pages, the
   guides/blogs sidebars auto-list their `posts/` directory, and the recipes
   sidebar lists category index pages, so a newly published post appears

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
 [project.scripts]
 publish = "site_publish.cli:publish"
 new = "site_publish.cli:new_draft"
+announce = "site_publish.cli:announce"
 
 [build-system]
 requires = ["hatchling"]

--- a/site_publish/announce.py
+++ b/site_publish/announce.py
@@ -1,0 +1,60 @@
+"""Compose a Bluesky announcement from a published vault draft.
+
+The blog track publishes as a Substack embed, so a blog draft already carries
+the canonical ``substack:`` URL to point the announcement at. For other
+sections (or to point somewhere else) pass an explicit ``--url``.
+
+Composition is deliberately thin: a headline + the link, with hashtags only if
+asked for. ``bluesky.detect_facets`` makes the link (and any ``#tags``)
+clickable, so the text we build here is just plain prose.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True)
+class Announcement:
+    text: str
+    url: str | None
+
+
+def _draft_meta(draft: Path) -> dict[str, Any]:
+    import frontmatter
+
+    if not draft.exists():
+        raise ValueError(f"Draft not found: {draft}")
+    return frontmatter.load(str(draft)).metadata
+
+
+def compose(
+    *,
+    draft: Path | None = None,
+    title: str | None = None,
+    url: str | None = None,
+    tags: list[str] | None = None,
+    lead: str = "New post",
+) -> Announcement:
+    """Build the announcement text from a draft and/or explicit overrides."""
+    meta = _draft_meta(draft) if draft else {}
+    title = title or meta.get("title")
+    # Blogs store the canonical link in `substack:`; --url overrides anything.
+    url = url or meta.get("substack")
+
+    if not title:
+        raise ValueError("No title: pass --title or a draft with a 'title'.")
+    if not url:
+        raise ValueError(
+            "No link: pass --url (or publish a blog draft that has a "
+            "'substack:' URL)."
+        )
+
+    text = f"{lead} — {title}\n\n{url}"
+    if tags:
+        cleaned = [t.lstrip("#").strip() for t in tags if t.strip()]
+        if cleaned:
+            text += "\n\n" + " ".join(f"#{t}" for t in cleaned)
+    return Announcement(text=text, url=url)

--- a/site_publish/bluesky.py
+++ b/site_publish/bluesky.py
@@ -1,0 +1,151 @@
+"""Minimal Bluesky (AT Protocol) post client -- stdlib only, no SDK.
+
+Implements the two-call flow from https://docs.bsky.app/blog/create-post:
+
+1. ``com.atproto.server.createSession`` with an identifier + app password to
+   get a short-lived ``accessJwt`` and the account ``did``.
+2. ``com.atproto.repo.createRecord`` to write an ``app.bsky.feed.post`` record.
+
+Rich-text **facets** (clickable links and hashtags) are byte-indexed into the
+UTF-8 text, so we detect them on the encoded bytes -- the indices the API
+expects are byte offsets, not character offsets.
+
+This module knows nothing about where the password comes from; the caller
+passes it in (see ``secrets.py`` for the Bitwarden boundary).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+DEFAULT_SERVICE = "https://bsky.social"
+
+# Detected on the UTF-8 *bytes* so match offsets are byte offsets (what facets
+# need). Trailing punctuation is trimmed from links so a sentence-final URL
+# doesn't swallow the period.
+_URL_RE = re.compile(rb"https?://[^\s\]\)>]+")
+_TAG_RE = re.compile(rb"(?:^|\s)(#[A-Za-z][A-Za-z0-9_]*)")
+_URL_TRAILING = b".,;:!?)\"'"
+
+
+class BlueskyError(RuntimeError):
+    """A createSession / createRecord call failed."""
+
+
+def detect_facets(text: str) -> list[dict[str, Any]]:
+    """Build the ``facets`` array (link + hashtag features) for ``text``.
+
+    Indices are UTF-8 byte offsets, per the AT Protocol spec.
+    """
+    raw = text.encode("utf-8")
+    facets: list[dict[str, Any]] = []
+
+    for m in _URL_RE.finditer(raw):
+        start, end = m.start(), m.end()
+        # Trim trailing punctuation that isn't really part of the URL.
+        # raw[i] is an int; `int in bytes` tests the byte value.
+        while end > start and raw[end - 1] in _URL_TRAILING:
+            end -= 1
+        uri = raw[start:end].decode("utf-8")
+        facets.append(
+            {
+                "index": {"byteStart": start, "byteEnd": end},
+                "features": [
+                    {"$type": "app.bsky.richtext.facet#link", "uri": uri}
+                ],
+            }
+        )
+
+    for m in _TAG_RE.finditer(raw):
+        start, end = m.start(1), m.end(1)  # group 1 excludes the leading space
+        tag = raw[start:end].decode("utf-8").lstrip("#")
+        facets.append(
+            {
+                "index": {"byteStart": start, "byteEnd": end},
+                "features": [
+                    {"$type": "app.bsky.richtext.facet#tag", "tag": tag}
+                ],
+            }
+        )
+
+    facets.sort(key=lambda f: f["index"]["byteStart"])
+    return facets
+
+
+def _post_json(
+    url: str, payload: dict[str, Any], *, token: str | None = None
+) -> dict[str, Any]:
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, method="POST")
+    req.add_header("Content-Type", "application/json")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        # The body may name the error (e.g. AuthenticationRequired) but never
+        # echoes the password back, so it's safe to surface.
+        raise BlueskyError(f"{url} -> HTTP {exc.code}: {body}") from exc
+    except urllib.error.URLError as exc:
+        raise BlueskyError(f"{url} unreachable: {exc.reason}") from exc
+
+
+def create_session(
+    identifier: str, password: str, *, service: str = DEFAULT_SERVICE
+) -> dict[str, Any]:
+    """Exchange an identifier + app password for a session (accessJwt, did)."""
+    return _post_json(
+        f"{service}/xrpc/com.atproto.server.createSession",
+        {"identifier": identifier, "password": password},
+    )
+
+
+def _now_iso() -> str:
+    # Trailing 'Z' is preferred over '+00:00' per the docs.
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+        "+00:00", "Z"
+    )
+
+
+def create_post(
+    session: dict[str, Any],
+    text: str,
+    *,
+    langs: tuple[str, ...] = ("en",),
+    service: str = DEFAULT_SERVICE,
+) -> dict[str, Any]:
+    """Create an ``app.bsky.feed.post`` record; returns the API response (uri, cid)."""
+    record: dict[str, Any] = {
+        "$type": "app.bsky.feed.post",
+        "text": text,
+        "createdAt": _now_iso(),
+        "langs": list(langs),
+    }
+    facets = detect_facets(text)
+    if facets:
+        record["facets"] = facets
+
+    return _post_json(
+        f"{service}/xrpc/com.atproto.repo.createRecord",
+        {
+            "repo": session["did"],
+            "collection": "app.bsky.feed.post",
+            "record": record,
+        },
+        token=session["accessJwt"],
+    )
+
+
+def post_web_url(handle: str, at_uri: str) -> str | None:
+    """Turn an ``at://did/app.bsky.feed.post/<rkey>`` URI into a bsky.app link."""
+    rkey = at_uri.rsplit("/", 1)[-1] if at_uri else ""
+    if not rkey:
+        return None
+    return f"https://bsky.app/profile/{handle}/post/{rkey}"

--- a/site_publish/cli.py
+++ b/site_publish/cli.py
@@ -7,6 +7,7 @@ import datetime as _dt
 import sys
 from pathlib import Path
 
+from . import announce as _announce
 from . import config, convert, frontmatter_map
 from .convert import ConvertError
 from .frontmatter_map import FrontmatterError
@@ -119,6 +120,80 @@ def new_draft(argv: list[str] | None = None) -> int:
     dest.parent.mkdir(parents=True, exist_ok=True)
     dest.write_text(content, encoding="utf-8")
     print(f"Created {dest}")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# announce (Bluesky)
+# --------------------------------------------------------------------------- #
+def announce(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="announce",
+        description="Post a Bluesky announcement for a published post. Reads "
+        "the app password from Bitwarden (bw) -- never from a file.",
+    )
+    parser.add_argument(
+        "file", nargs="?", help="A published vault draft (.md); supplies title + link."
+    )
+    parser.add_argument("--title", help="Override the post title.")
+    parser.add_argument(
+        "--url", help="Link to announce (required if no draft / non-blog draft)."
+    )
+    parser.add_argument(
+        "--tag", action="append", default=[], metavar="TAG",
+        help="Hashtag to append (repeatable; '#' optional). Lowercase, few.",
+    )
+    parser.add_argument(
+        "--text", help="Use this exact post text verbatim (skips composition)."
+    )
+    parser.add_argument("--item", help="Bitwarden item name/id (default $BLUESKY_BW_ITEM or 'Bluesky').")
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Compose and print the post (with detected facets); do not auth or send.",
+    )
+    args = parser.parse_args(argv)
+
+    from . import bluesky
+
+    if args.text:
+        text = args.text
+    else:
+        try:
+            ann = _announce.compose(
+                draft=Path(args.file) if args.file else None,
+                title=args.title,
+                url=args.url,
+                tags=args.tag,
+            )
+        except ValueError as exc:
+            parser.error(str(exc))
+        text = ann.text
+
+    if args.dry_run:
+        import json
+        print("--- post text ---")
+        print(text)
+        print("--- facets ---")
+        print(json.dumps(bluesky.detect_facets(text), indent=2))
+        print("\n(dry run: nothing sent, Bitwarden not touched)")
+        return 0
+
+    from . import secrets
+    from .bluesky import BlueskyError
+    from .secrets import SecretError
+
+    try:
+        identifier, password = secrets.bluesky_credentials(args.item)
+        session = bluesky.create_session(identifier, password)
+        resp = bluesky.create_post(session, text)
+    except (SecretError, BlueskyError) as exc:
+        print(f"  ✗ {exc}", file=sys.stderr)
+        return 1
+
+    web = bluesky.post_web_url(identifier, resp.get("uri", ""))
+    print(f"  ✓ Posted to Bluesky as {identifier}")
+    if web:
+        print(f"      {web}")
     return 0
 
 

--- a/site_publish/secrets.py
+++ b/site_publish/secrets.py
@@ -1,0 +1,86 @@
+"""The one boundary between the app and the secret store (Bitwarden CLI).
+
+Per the canonical ``secrets-no-plaintext`` convention, secret access funnels
+through a single module so the backend is swappable and the audit surface is
+one file. Here the backend is the Bitwarden ``bw`` CLI vault: the Bluesky app
+password lives in a vault item and is read at run time -- never written to a
+file, never echoed.
+
+Prereqs at call time (the documented bootstrap exception is the one env var
+that unlocks the store itself):
+
+- ``bw`` installed and logged in (``bw login`` once).
+- The vault unlocked for this shell: ``export BW_SESSION="$(bw unlock --raw)"``.
+  ``bw`` reads ``BW_SESSION`` from the environment automatically.
+
+Configuration (non-secret) via env:
+
+- ``BLUESKY_BW_ITEM`` -- name or id of the Bitwarden item holding the Bluesky
+  login (default ``"Bluesky"``). Its ``login.username`` is the handle/identifier
+  and ``login.password`` is the app password.
+- ``BLUESKY_HANDLE`` -- optional override for the identifier if it isn't stored
+  as the item's username.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+
+DEFAULT_ITEM = "Bluesky"
+
+
+class SecretError(RuntimeError):
+    """The secret could not be read (CLI missing, vault locked, item absent)."""
+
+
+def _bw(*args: str) -> str:
+    if shutil.which("bw") is None:
+        raise SecretError(
+            "Bitwarden CLI ('bw') not found. Install it and run `bw login`."
+        )
+    proc = subprocess.run(
+        ["bw", *args],
+        capture_output=True,
+        text=True,
+        env=os.environ,  # bw reads BW_SESSION from here.
+    )
+    if proc.returncode != 0:
+        err = (proc.stderr or proc.stdout).strip()
+        hint = ""
+        if "locked" in err.lower() or "logged in" in err.lower():
+            hint = (
+                "  Unlock first: export BW_SESSION=\"$(bw unlock --raw)\""
+            )
+        raise SecretError(f"`bw {' '.join(args)}` failed: {err}{hint}")
+    return proc.stdout
+
+
+def bluesky_credentials(item_ref: str | None = None) -> tuple[str, str]:
+    """Return ``(identifier, app_password)`` for Bluesky from the vault.
+
+    Reads one Bitwarden item; the password is never returned to the shell,
+    logged, or printed -- only handed to the API client.
+    """
+    item_ref = item_ref or os.environ.get("BLUESKY_BW_ITEM", DEFAULT_ITEM)
+    try:
+        item = json.loads(_bw("get", "item", item_ref))
+    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
+        raise SecretError(f"`bw get item {item_ref}` did not return JSON.") from exc
+
+    login = item.get("login") or {}
+    identifier = os.environ.get("BLUESKY_HANDLE") or login.get("username")
+    password = login.get("password")
+
+    if not identifier:
+        raise SecretError(
+            f"No identifier for Bluesky: set the username on item '{item_ref}' "
+            "or export BLUESKY_HANDLE."
+        )
+    if not password:
+        raise SecretError(
+            f"Item '{item_ref}' has no password (the Bluesky app password)."
+        )
+    return identifier, password


### PR DESCRIPTION
## What

Adds an `/announce` step to the vault→site publishing pipeline: post a short Bluesky update linking to a just-published post. Sibling to `/publish`; a **runtime action, not a code change** (no branch/PR when you run it).

## Where it lives & why

Lands in this repo because it already owns the publish→deploy automation (`/publish`, `site_publish/`) and the Python/uv runtime. It's scoped to lift cleanly into `content_manager`'s multi-platform poster later — the `bw`-CLI secrets shape here is the documented bridge until then.

## Pieces

- **`site_publish/bluesky.py`** — stdlib-only AT Protocol client (`createSession` → `createRecord`) with byte-indexed rich-text facets so links and `#tags` are clickable. No SDK, no new deps.
- **`site_publish/secrets.py`** — the single boundary to the Bitwarden `bw` CLI. The Bluesky **app password** is read at run time, never written to a file or printed. Matches the canonical `secrets-no-plaintext` convention. Env-driven config: `BLUESKY_BW_ITEM` (default `Bluesky`), `BLUESKY_HANDLE`.
- **`site_publish/announce.py` + `cli.py` `announce`** — compose from a blog draft's `title` + `substack:` URL (or `--url`/`--title`/`--text`/`--tag`), with a `--dry-run` that previews the text + facets without touching `bw` or the network.
- **`.claude/commands/announce.md`** — the `/announce` command: dry-run → unlock vault → send.
- pyproject `announce` script; `.gitignore` `.env`/`*.key`/`*.pem` hardening; CLAUDE.md pipeline doc.

## Bitwarden

Per the requirement, no secret in any text file. Create a Bluesky **app password** (Settings → App Passwords), store it on a `bw` item; the tool reads it via `bw get item`. Caller unlocks with `export BW_SESSION="$(bw unlock --raw)"`. For unattended/cron use later, `bws` (Secrets Manager + machine token) is the natural upgrade — same single-boundary shape.

## Delivered + Verified

- **Delivered:** `uv run announce <draft|--url> [--tag] --dry-run` composes the post with correct link + hashtag facets; dropping `--dry-run` posts via `bw`-sourced creds.
- **Verified:** facet byte-offset unit check (em-dash multibyte + trailing-period trim, `#`-stripped tags), dry-run compose, no-link error path, all modules import. No live Bluesky/`bw` call made in this session (vault not unlocked here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)