### PR TITLE
publish(blogs): add phone-sync post

### DIFF
--- a/docs/listings.json
+++ b/docs/listings.json
@@ -183,6 +183,7 @@
     "listing": "/pages/blogs/blogs.html",
     "items": [
       "/pages/blogs/posts/figuring-things-out.html",
+      "/pages/blogs/posts/phone-sync.html",
       "/pages/blogs/posts/test.html"
     ]
   },

--- a/docs/pages/blogs/blogs.html
+++ b/docs/pages/blogs/blogs.html
@@ -426,6 +426,12 @@ window.Quarto = {
 </li>
           <li class="sidebar-item">
   <div class="sidebar-item-container"> 
+  <a href="../../pages/blogs/posts/phone-sync.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Syncing an Obsidian Vault to iPhone over Git with Working Copy</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
   <a href="../../pages/blogs/posts/test.html" class="sidebar-item-text sidebar-link">
  <span class="menu-text">Test</span></a>
   </div>
@@ -441,7 +447,7 @@ window.Quarto = {
 <!-- margin-sidebar -->
     <div id="quarto-margin-sidebar" class="sidebar margin-sidebar">
         
-    <h5 class="quarto-listing-category-title">Categories</h5><div class="quarto-listing-category category-default"><div class="category" data-category="">All <span class="quarto-category-count">(2)</span></div><div class="category" data-category="YWk=">ai <span class="quarto-category-count">(1)</span></div><div class="category" data-category="YmxvZw==">blog <span class="quarto-category-count">(1)</span></div><div class="category" data-category="cmVzZWFyY2g=">research <span class="quarto-category-count">(1)</span></div><div class="category" data-category="VGVzdA==">Test <span class="quarto-category-count">(1)</span></div></div></div>
+    <h5 class="quarto-listing-category-title">Categories</h5><div class="quarto-listing-category category-default"><div class="category" data-category="">All <span class="quarto-category-count">(3)</span></div><div class="category" data-category="YWk=">ai <span class="quarto-category-count">(1)</span></div><div class="category" data-category="YmxvZw==">blog <span class="quarto-category-count">(2)</span></div><div class="category" data-category="Z3VpZGU=">guide <span class="quarto-category-count">(1)</span></div><div class="category" data-category="cmVzZWFyY2g=">research <span class="quarto-category-count">(1)</span></div><div class="category" data-category="VGVzdA==">Test <span class="quarto-category-count">(1)</span></div></div></div>
 <!-- main -->
 <main class="content" id="quarto-document-content">
 
@@ -472,7 +478,7 @@ window.Quarto = {
 
 <div class="quarto-listing quarto-listing-container-grid" id="listing-listing">
 <div class="list grid quarto-listing-cols-3">
-<div class="g-col-1" data-index="0" data-categories="YmxvZyUyQ2FpJTJDcmVzZWFyY2g=" data-listing-date-sort="1780718400000" data-listing-file-modified-sort="1780765165494" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="15">
+<div class="g-col-1" data-index="0" data-categories="YmxvZyUyQ2FpJTJDcmVzZWFyY2g=" data-listing-date-sort="1780718400000" data-listing-file-modified-sort="1780765474945" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="15">
 <a href="../../pages/blogs/posts/figuring-things-out.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="listing-item-img-placeholder card-img-top" style="height: 150px;">&nbsp;</div>
@@ -503,7 +509,36 @@ Jun 6, 2026
 </div>
 </div></a>
 </div>
-<div class="g-col-1" data-index="1" data-categories="VGVzdA==" data-listing-date-sort="1772773200000" data-listing-file-modified-sort="1780441052820" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="14">
+<div class="g-col-1" data-index="1" data-categories="YmxvZyUyQ2d1aWRl" data-listing-date-sort="1780632000000" data-listing-file-modified-sort="1780784221014" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="23">
+<a href="../../pages/blogs/posts/phone-sync.html" class="quarto-grid-link">
+<div class="quarto-grid-item card h-100 card-left">
+<div class="listing-item-img-placeholder card-img-top" style="height: 150px;">&nbsp;</div>
+<div class="card-body post-contents">
+<h5 class="no-anchor card-title listing-title">
+Syncing an Obsidian Vault to iPhone over Git with Working Copy
+</h5>
+<div class="listing-categories">
+
+<div class="listing-category" onclick="window.quartoListingCategory('YmxvZw=='); return false;">blog</div>
+
+<div class="listing-category" onclick="window.quartoListingCategory('Z3VpZGU='); return false;">guide</div>
+
+</div>
+<div class="card-text listing-description delink">
+Syncing an Obsidian Vault to iPhone over Git with Working Copy by Chris Kornaros
+</div>
+<div class="card-attribution card-text-small justify">
+<div class="listing-author">
+Chris Kornaros
+</div>
+<div class="listing-date">
+Jun 5, 2026
+</div>
+</div>
+</div>
+</div></a>
+</div>
+<div class="g-col-1" data-index="2" data-categories="VGVzdA==" data-listing-date-sort="1772773200000" data-listing-file-modified-sort="1780441052820" data-listing-date-modified-sort="NaN" data-listing-reading-time-sort="1" data-listing-word-count-sort="14">
 <a href="../../pages/blogs/posts/test.html" class="quarto-grid-link">
 <div class="quarto-grid-item card h-100 card-left">
 <div class="listing-item-img-placeholder card-img-top" style="height: 150px;">&nbsp;</div>

--- a/docs/pages/blogs/posts/figuring-things-out.html
+++ b/docs/pages/blogs/posts/figuring-things-out.html
@@ -366,6 +366,12 @@ cookieconsent.run({
 </li>
           <li class="sidebar-item">
   <div class="sidebar-item-container"> 
+  <a href="../../../pages/blogs/posts/phone-sync.html" class="sidebar-item-text sidebar-link">
+ <span class="menu-text">Syncing an Obsidian Vault to iPhone over Git with Working Copy</span></a>
+  </div>
+</li>
+          <li class="sidebar-item">
+  <div class="sidebar-item-container"> 
   <a href="../../../pages/blogs/posts/test.html" class="sidebar-item-text sidebar-link">
  <span class="menu-text">Test</span></a>
   </div>

--- a/docs/pages/blogs/posts/phone-sync.html
+++ b/docs/pages/blogs/posts/phone-sync.html
@@ -7,9 +7,9 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
 <meta name="author" content="Chris Kornaros">
-<meta name="dcterms.date" content="2026-03-06">
+<meta name="dcterms.date" content="2026-06-05">
 
-<title>Test – Chris Kornaros</title>
+<title>Syncing an Obsidian Vault to iPhone over Git with Working Copy – Chris Kornaros</title>
 <style>
 /* Default styles provided by pandoc.
 ** See https://pandoc.org/MANUAL.html#variables-for-html for config info.
@@ -107,9 +107,9 @@ cookieconsent.run({
   
 
 
-<meta property="og:title" content="Test – Chris Kornaros">
+<meta property="og:title" content="Syncing an Obsidian Vault to iPhone over Git with Working Copy – Chris Kornaros">
 <meta property="og:site_name" content="Chris Kornaros">
-<meta name="twitter:title" content="Test – Chris Kornaros">
+<meta name="twitter:title" content="Syncing an Obsidian Vault to iPhone over Git with Working Copy – Chris Kornaros">
 <meta name="twitter:card" content="summary">
 </head>
 
@@ -328,7 +328,7 @@ cookieconsent.run({
       <button type="button" class="quarto-btn-toggle btn" data-bs-toggle="collapse" role="button" data-bs-target=".quarto-sidebar-collapse-item" aria-controls="quarto-sidebar" aria-expanded="false" aria-label="Toggle sidebar navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">
         <i class="bi bi-layout-text-sidebar-reverse"></i>
       </button>
-        <nav class="quarto-page-breadcrumbs" aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="../../../pages/blogs/blogs.html">Blogs</a></li><li class="breadcrumb-item"><a href="../../../pages/blogs/posts/figuring-things-out.html">Posts</a></li><li class="breadcrumb-item"><a href="../../../pages/blogs/posts/test.html">Test</a></li></ol></nav>
+        <nav class="quarto-page-breadcrumbs" aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="../../../pages/blogs/blogs.html">Blogs</a></li><li class="breadcrumb-item"><a href="../../../pages/blogs/posts/figuring-things-out.html">Posts</a></li><li class="breadcrumb-item"><a href="../../../pages/blogs/posts/phone-sync.html">Syncing an Obsidian Vault to iPhone over Git with Working Copy</a></li></ol></nav>
         <a class="flex-grow-1" role="navigation" data-bs-toggle="collapse" data-bs-target=".quarto-sidebar-collapse-item" aria-controls="quarto-sidebar" aria-expanded="false" aria-label="Toggle sidebar navigation" onclick="if (window.quartoToggleHeadroom) { window.quartoToggleHeadroom(); }">      
         </a>
     </div>
@@ -366,13 +366,13 @@ cookieconsent.run({
 </li>
           <li class="sidebar-item">
   <div class="sidebar-item-container"> 
-  <a href="../../../pages/blogs/posts/phone-sync.html" class="sidebar-item-text sidebar-link">
+  <a href="../../../pages/blogs/posts/phone-sync.html" class="sidebar-item-text sidebar-link active">
  <span class="menu-text">Syncing an Obsidian Vault to iPhone over Git with Working Copy</span></a>
   </div>
 </li>
           <li class="sidebar-item">
   <div class="sidebar-item-container"> 
-  <a href="../../../pages/blogs/posts/test.html" class="sidebar-item-text sidebar-link active">
+  <a href="../../../pages/blogs/posts/test.html" class="sidebar-item-text sidebar-link">
  <span class="menu-text">Test</span></a>
   </div>
 </li>
@@ -392,11 +392,12 @@ cookieconsent.run({
 <main class="content" id="quarto-document-content">
 
 
-<header id="title-block-header" class="quarto-title-block default"><nav class="quarto-page-breadcrumbs quarto-title-breadcrumbs d-none d-lg-block" aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="../../../pages/blogs/blogs.html">Blogs</a></li><li class="breadcrumb-item"><a href="../../../pages/blogs/posts/figuring-things-out.html">Posts</a></li><li class="breadcrumb-item"><a href="../../../pages/blogs/posts/test.html">Test</a></li></ol></nav>
+<header id="title-block-header" class="quarto-title-block default"><nav class="quarto-page-breadcrumbs quarto-title-breadcrumbs d-none d-lg-block" aria-label="breadcrumb"><ol class="breadcrumb"><li class="breadcrumb-item"><a href="../../../pages/blogs/blogs.html">Blogs</a></li><li class="breadcrumb-item"><a href="../../../pages/blogs/posts/figuring-things-out.html">Posts</a></li><li class="breadcrumb-item"><a href="../../../pages/blogs/posts/phone-sync.html">Syncing an Obsidian Vault to iPhone over Git with Working Copy</a></li></ol></nav>
 <div class="quarto-title">
-<h1 class="title">Test</h1>
+<h1 class="title">Syncing an Obsidian Vault to iPhone over Git with Working Copy</h1>
   <div class="quarto-categories">
-    <div class="quarto-category">Test</div>
+    <div class="quarto-category">blog</div>
+    <div class="quarto-category">guide</div>
   </div>
   </div>
 
@@ -414,7 +415,7 @@ cookieconsent.run({
     <div>
     <div class="quarto-title-meta-heading">Published</div>
     <div class="quarto-title-meta-contents">
-      <p class="date">March 6, 2026</p>
+      <p class="date">June 5, 2026</p>
     </div>
   </div>
   
@@ -426,7 +427,7 @@ cookieconsent.run({
 </header>
 
 
-<div class="substack-post-embed"><p lang="en">Test Post by Chris Kornaros</p><p></p><a data-post-link="" href="https://chriskornaros.substack.com/p/test-post">Read on Substack</a></div><script async="" src="https://substack.com/embedjs/embed.js" charset="utf-8"></script>
+<div class="substack-post-embed"><p lang="en">Syncing an Obsidian Vault to iPhone over Git with Working Copy by Chris Kornaros</p><p></p><a data-post-link="" href="https://chriskornaros.substack.com/p/syncing-my-notes-across-devices">Read on Substack</a></div><script async="" src="https://substack.com/embedjs/embed.js" charset="utf-8"></script>
 
 
 
@@ -873,7 +874,7 @@ cookieconsent.run({
 </a>
   </li>  
 </ul>
-    <div class="toc-actions"><ul><li><a href="https://github.com/ChrisKornaros/ChrisKornaros.github.io/blob/main/pages/blogs/posts/test.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ChrisKornaros/ChrisKornaros.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div><div class="cookie-consent-footer"><a href="#" id="open_preferences_center">Cookie Preferences</a></div></div>
+    <div class="toc-actions"><ul><li><a href="https://github.com/ChrisKornaros/ChrisKornaros.github.io/blob/main/pages/blogs/posts/phone-sync.qmd" class="toc-action"><i class="bi bi-github"></i>View source</a></li><li><a href="https://github.com/ChrisKornaros/ChrisKornaros.github.io/issues/new" class="toc-action"><i class="bi empty"></i>Report an issue</a></li></ul></div><div class="cookie-consent-footer"><a href="#" id="open_preferences_center">Cookie Preferences</a></div></div>
     <div class="nav-footer-right">
       &nbsp;
     </div>

--- a/docs/search.json
+++ b/docs/search.json
@@ -703,24 +703,6 @@
     ]
   },
   {
-    "objectID": "pages/research/research.html",
-    "href": "pages/research/research.html",
-    "title": "Research",
-    "section": "",
-    "text": "A space for independent research, notes, and longer-form explorations. Still early — more to come.\n\n\n\n\n\n\n\n\nNo matching items",
-    "crumbs": [
-      "Home",
-      "Research"
-    ]
-  },
-  {
-    "objectID": "index.html",
-    "href": "index.html",
-    "title": "Chris Kornaros",
-    "section": "",
-    "text": "This site is the personal portfolio and homepage for Chris Kornaros. I’m a Tulane Graduate and professional Data Engineer. On here, you’ll find projects and code samples that I can share publicly, guides for various tools or workflows, journal or blog posts, and any independent research or professional updates (including my resume).\nThis website is a work in progress, so things are going to move around and break. Additionally, there is a lot that I have to still add: past guides, projects, etc. Follow me on social media (links above) to stay up to date with what I’m working on. To learn more about my background visit About, for guides on various open source tools visit Guides, to see my current and past (public) work visit Projects, and to see any blog posts (available on WhiteWind) visit Blogs."
-  },
-  {
     "objectID": "pages/blogs/posts/figuring-things-out.html",
     "href": "pages/blogs/posts/figuring-things-out.html",
     "title": "Figuring things out…",
@@ -734,11 +716,42 @@
     ]
   },
   {
+    "objectID": "index.html",
+    "href": "index.html",
+    "title": "Chris Kornaros",
+    "section": "",
+    "text": "This site is the personal portfolio and homepage for Chris Kornaros. I’m a Tulane Graduate and professional Data Engineer. On here, you’ll find projects and code samples that I can share publicly, guides for various tools or workflows, journal or blog posts, and any independent research or professional updates (including my resume).\nThis website is a work in progress, so things are going to move around and break. Additionally, there is a lot that I have to still add: past guides, projects, etc. Follow me on social media (links above) to stay up to date with what I’m working on. To learn more about my background visit About, for guides on various open source tools visit Guides, to see my current and past (public) work visit Projects, and to see any blog posts (available on WhiteWind) visit Blogs."
+  },
+  {
+    "objectID": "pages/research/research.html",
+    "href": "pages/research/research.html",
+    "title": "Research",
+    "section": "",
+    "text": "A space for independent research, notes, and longer-form explorations. Still early — more to come.\n\n\n\n\n\n\n\n\nNo matching items",
+    "crumbs": [
+      "Home",
+      "Research"
+    ]
+  },
+  {
+    "objectID": "pages/blogs/posts/phone-sync.html",
+    "href": "pages/blogs/posts/phone-sync.html",
+    "title": "Syncing an Obsidian Vault to iPhone over Git with Working Copy",
+    "section": "",
+    "text": "Syncing an Obsidian Vault to iPhone over Git with Working Copy by Chris KornarosRead on Substack",
+    "crumbs": [
+      "Home",
+      "Blogs",
+      "Posts",
+      "Syncing an Obsidian Vault to iPhone over Git with Working Copy"
+    ]
+  },
+  {
     "objectID": "pages/blogs/blogs.html",
     "href": "pages/blogs/blogs.html",
     "title": "Blogs",
     "section": "",
-    "text": "A landing page for various blogs, journals, or random thoughts. Some of these will be focused on specific tools or technology, others will be random thoughts or research notes.\n\n\n\n\n\n\n\n\n\n\n\n\nFiguring things out…\n\n\n\nblog\n\nai\n\nresearch\n\n\n\n\n\n\n\nChris Kornaros\n\n\nJun 6, 2026\n\n\n\n\n\n\n\n\n\n\n\nTest\n\n\n\nTest\n\n\n\n\n\n\n\nChris Kornaros\n\n\nMar 6, 2026\n\n\n\n\n\n\nNo matching items",
+    "text": "A landing page for various blogs, journals, or random thoughts. Some of these will be focused on specific tools or technology, others will be random thoughts or research notes.\n\n\n\n\n\n\n\n\n\n\n\n\nFiguring things out…\n\n\n\nblog\n\nai\n\nresearch\n\n\n\n\n\n\n\nChris Kornaros\n\n\nJun 6, 2026\n\n\n\n\n\n\n\n\n\n\n\nSyncing an Obsidian Vault to iPhone over Git with Working Copy\n\n\n\nblog\n\nguide\n\n\n\n\n\n\n\nChris Kornaros\n\n\nJun 5, 2026\n\n\n\n\n\n\n\n\n\n\n\nTest\n\n\n\nTest\n\n\n\n\n\n\n\nChris Kornaros\n\n\nMar 6, 2026\n\n\n\n\n\n\nNo matching items",
     "crumbs": [
       "Home",
       "Blogs"

--- a/source/pages/blogs/posts/phone-sync.qmd
+++ b/source/pages/blogs/posts/phone-sync.qmd
@@ -1,0 +1,13 @@
+---
+title: Syncing an Obsidian Vault to iPhone over Git with Working Copy
+author: Chris Kornaros
+date: 2026-06-05
+categories:
+- blog
+- guide
+published: '2026-06-06'
+---
+
+```{=html}
+<div class="substack-post-embed"><p lang="en">Syncing an Obsidian Vault to iPhone over Git with Working Copy by Chris Kornaros</p><p></p><a data-post-link href="https://chriskornaros.substack.com/p/syncing-my-notes-across-devices">Read on Substack</a></div><script async src="https://substack.com/embedjs/embed.js" charset="utf-8"></script>
+```


### PR DESCRIPTION
## Summary

Publishes the **phone-sync** blog post from the vault draft.

- Converts `~/vault/writing/blogs/phone-sync.md` → `source/pages/blogs/posts/phone-sync.qmd` via the deterministic publish CLI.
- Re-renders the tracked `docs/` (new `phone-sync.html`, regenerated blogs listing + search index).
- Vault source un-drafted (canonical `.md` stays in the vault, not committed here).

## Delivered + Verified

- **Delivered:** new blog post `phone-sync` live on merge → GitHub Pages.
- **Verified:** `uv run quarto render source` finished with `Output created:` (only the two expected `../docs` path WARNs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)