### PR TITLE
feat(announce): new Bluesky post format + clean canonical link

### DIFF
--- a/.claude/commands/announce.md
+++ b/.claude/commands/announce.md
@@ -10,7 +10,7 @@ a code change — it creates **no git branch, commit, or PR**. (The `announce`
 command itself was added to the repo in its own PR; running it just posts.)
 
 Arguments: `$ARGUMENTS` — a published vault draft path (supplies title + link),
-and/or `--url`, `--title`, `--tag`, `--text`, `--item`, `--dry-run`.
+and/or `--url`, `--tag`, `--text`, `--item`, `--dry-run`.
 
 Run everything from the repo root (`~/vault/projects/ChrisKornaros.github.io`).
 
@@ -21,8 +21,8 @@ Run: `uv run announce $ARGUMENTS --dry-run`
 - This composes the post and prints it plus the detected facets (clickable link
   + any `#tags`). It does **not** touch Bitwarden or the network.
 - For a blog draft the link comes from the draft's `substack:` frontmatter; for
-  anything else pass `--url`. Override the headline with `--title`, the whole
-  text with `--text`, and add hashtags with `--tag` (lowercase, few).
+  anything else pass `--url`. Override the whole text with `--text`, and add
+  hashtags with `--tag` (lowercase, few).
 - Show Chris the composed post and confirm it reads right before sending.
 
 ## 2. Make sure the Bitwarden vault is unlocked

--- a/site_publish/announce.py
+++ b/site_publish/announce.py
@@ -4,9 +4,9 @@ The blog track publishes as a Substack embed, so a blog draft already carries
 the canonical ``substack:`` URL to point the announcement at. For other
 sections (or to point somewhere else) pass an explicit ``--url``.
 
-Composition is deliberately thin: a headline + the link, with hashtags only if
-asked for. ``bluesky.detect_facets`` makes the link (and any ``#tags``)
-clickable, so the text we build here is just plain prose.
+Composition is deliberately thin: a fixed invitation line + the link, with
+hashtags only if asked for. ``bluesky.detect_facets`` makes the link (and any
+``#tags``) clickable, so the text we build here is just plain prose.
 """
 
 from __future__ import annotations
@@ -14,6 +14,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
+
+from . import embeds
 
 
 @dataclass(frozen=True)
@@ -33,26 +35,29 @@ def _draft_meta(draft: Path) -> dict[str, Any]:
 def compose(
     *,
     draft: Path | None = None,
-    title: str | None = None,
     url: str | None = None,
     tags: list[str] | None = None,
-    lead: str = "New post",
 ) -> Announcement:
     """Build the announcement text from a draft and/or explicit overrides."""
     meta = _draft_meta(draft) if draft else {}
-    title = title or meta.get("title")
-    # Blogs store the canonical link in `substack:`; --url overrides anything.
-    url = url or meta.get("substack")
+    # An explicit --url is posted verbatim; a blog draft's `substack:` link is
+    # normalized to the canonical post URL via the same transform the embed
+    # uses, so we announce the clean link rather than the tracking-param
+    # "Share" form.
+    if url is None:
+        share = meta.get("substack")
+        url = embeds.canonical_substack_url(share) if share else None
 
-    if not title:
-        raise ValueError("No title: pass --title or a draft with a 'title'.")
     if not url:
         raise ValueError(
             "No link: pass --url (or publish a blog draft that has a "
             "'substack:' URL)."
         )
 
-    text = f"{lead} — {title}\n\n{url}"
+    text = (
+        "I just posted a new blog to substack, check it out and let me know "
+        f"what you think! {url}"
+    )
     if tags:
         cleaned = [t.lstrip("#").strip() for t in tags if t.strip()]
         if cleaned:

--- a/site_publish/cli.py
+++ b/site_publish/cli.py
@@ -135,7 +135,6 @@ def announce(argv: list[str] | None = None) -> int:
     parser.add_argument(
         "file", nargs="?", help="A published vault draft (.md); supplies title + link."
     )
-    parser.add_argument("--title", help="Override the post title.")
     parser.add_argument(
         "--url", help="Link to announce (required if no draft / non-blog draft)."
     )
@@ -161,7 +160,6 @@ def announce(argv: list[str] | None = None) -> int:
         try:
             ann = _announce.compose(
                 draft=Path(args.file) if args.file else None,
-                title=args.title,
                 url=args.url,
                 tags=args.tag,
             )

--- a/site_publish/embeds.py
+++ b/site_publish/embeds.py
@@ -13,7 +13,7 @@ _YT_ID = re.compile(r"^[A-Za-z0-9_-]{11}$")
 _SHARE_PATH = re.compile(r"^/pub/([^/]+)/p/(.+)$")
 
 
-def _canonical_substack_url(url: str) -> str:
+def canonical_substack_url(url: str) -> str:
     """Normalize a Substack URL to the canonical post form for embedding.
 
     Substack's "Share" button hands out a tracking link
@@ -37,7 +37,7 @@ def _canonical_substack_url(url: str) -> str:
 
 def substack_embed(title: str, url: str) -> str:
     """Substack post embed stub (verbatim shape of the existing test.qmd)."""
-    url = _canonical_substack_url(url)
+    url = canonical_substack_url(url)
     return (
         "```{=html}\n"
         f'<div class="substack-post-embed"><p lang="en">{title} by '


### PR DESCRIPTION
## Summary

Reworks the composed Bluesky announcement (`/announce`) to a fixed invitation line and a clean link.

**New post text:**
> I just posted a new blog to substack, check it out and let me know what you think! <link>

## Changes

- **`site_publish/announce.py`** — `compose()` now builds the fixed invitation line + inline link. Dropped the `title`/`lead` headline params and the title requirement (the new format has no title slot).
- **`site_publish/cli.py`** — removed the now-dead `--title` flag and its `compose()` argument.
- **`site_publish/embeds.py`** — promoted `_canonical_substack_url` → `canonical_substack_url` (public) so the announce path can reuse it.
- **announce composer** — the blog's `substack:` link is normalized to the canonical `<pub>.substack.com/p/<slug>` form (same transform the embed uses), so the announced URL matches the embed and drops the `?r=…&utm_…&showWelcomeOnShare=true` tracking tail. An explicit `--url` is still posted verbatim.
- **`.claude/commands/announce.md`** — dropped the two `--title` references.

## Delivered + Verified

- **Delivered:** new announcement format with a clean canonical Substack link; `--title` removed.
- **Verified:** `uv run announce <draft> --dry-run` composes
  `I just posted a new blog to substack, check it out and let me know what you think! https://chriskornaros.substack.com/p/syncing-my-notes-across-devices`
  with a correct single link facet; `import site_publish.{announce,cli,embeds,convert}` clean. Tooling-only change — no `docs/` render needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)