### PR TITLE
fix(announce): read Bluesky creds via bw get + interactive unlock

### DIFF
--- a/.claude/commands/announce.md
+++ b/.claude/commands/announce.md
@@ -25,20 +25,27 @@ Run: `uv run announce $ARGUMENTS --dry-run`
   hashtags with `--tag` (lowercase, few).
 - Show Chris the composed post and confirm it reads right before sending.
 
-## 2. Make sure the Bitwarden vault is unlocked
+## 2. Bitwarden vault — unlock is handled for you (on a terminal)
 
 The send step reads the Bluesky **app password** (not the account password)
-from a Bitwarden item via the `bw` CLI. It needs an unlocked vault in the shell:
+from a Bitwarden item via the `bw` CLI. If the vault is locked **and you're at a
+terminal**, `announce` runs `bw unlock` itself — the master-password prompt
+shows inline, you type it, and it proceeds. The session key is captured, never
+printed. So no pre-export is required for interactive use; you *can* still
+pre-unlock if you prefer:
 
 ```sh
 export BW_SESSION="$(bw unlock --raw)"
 ```
 
+- With **no tty** (CI, or a captured subprocess — e.g. an agent's Bash tool),
+  there's no way to prompt, so it fails with the manual-unlock hint instead of
+  hanging. In that case run the pre-export above first.
 - Config (non-secret) is env-driven: `BLUESKY_BW_ITEM` (default `Bluesky`) names
   the vault item; its username is the handle and its password is the app
   password. `BLUESKY_HANDLE` overrides the identifier if needed.
-- Never print, echo, or log the password. If `bw` reports the vault is locked or
-  you're not logged in, surface that and stop — don't work around it.
+- Never print, echo, or log the password. If `bw` reports it's not logged in,
+  surface that and stop — don't work around it.
 
 ## 3. Send
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,8 +109,10 @@ A draft is the canonical source; the site `.qmd` is generated from it.
   facets, no network); dropping `--dry-run` sends it. It's a **runtime action,
   not a code change** — no branch/PR. The Bluesky **app password** is read at
   run time from a Bitwarden item via the `bw` CLI through the single
-  [site_publish/secrets.py](site_publish/secrets.py) boundary (unlock first:
-  `export BW_SESSION="$(bw unlock --raw)"`); it's never written to a file or
+  [site_publish/secrets.py](site_publish/secrets.py) boundary via two narrow
+  reads (`bw get username` / `bw get password`); a locked vault is unlocked
+  interactively when run at a terminal (else pre-export
+  `BW_SESSION="$(bw unlock --raw)"`). The password is never written to a file or
   printed. Config is env-driven (`BLUESKY_BW_ITEM`, default `Bluesky`;
   `BLUESKY_HANDLE` to override the identifier). Folds into `content_manager`'s
   multi-platform poster later — the `bw`-CLI shape is the documented bridge.

--- a/site_publish/secrets.py
+++ b/site_publish/secrets.py
@@ -6,18 +6,30 @@ one file. Here the backend is the Bitwarden ``bw`` CLI vault: the Bluesky app
 password lives in a vault item and is read at run time -- never written to a
 file, never echoed.
 
-Prereqs at call time (the documented bootstrap exception is the one env var
-that unlocks the store itself):
+Two narrow reads do the work -- ``bw get username`` and ``bw get password`` --
+rather than fetching the whole item as JSON. That sidesteps a brittle failure
+mode (a ``bw`` update notice or a "more than one result" message prepended to
+stdout makes ``json.loads`` blow up with no useful error) and uses exactly the
+commands that return the raw value.
+
+Unlock is handled here too: if the vault is locked and we're on a terminal,
+``bw unlock`` is run interactively -- the master-password prompt shows on the
+tty, the session key is captured (never printed) and stashed in the environment
+for the ``bw get`` calls that follow. With no tty (CI, a captured subprocess)
+we fail with the manual-unlock hint instead of hanging on an invisible prompt.
+
+Prereqs at call time:
 
 - ``bw`` installed and logged in (``bw login`` once).
-- The vault unlocked for this shell: ``export BW_SESSION="$(bw unlock --raw)"``.
-  ``bw`` reads ``BW_SESSION`` from the environment automatically.
+- Either the vault already unlocked for this shell
+  (``export BW_SESSION="$(bw unlock --raw)"``) or an interactive terminal so we
+  can unlock it for you. ``bw`` reads ``BW_SESSION`` from the environment.
 
 Configuration (non-secret) via env:
 
 - ``BLUESKY_BW_ITEM`` -- name or id of the Bitwarden item holding the Bluesky
-  login (default ``"Bluesky"``). Its ``login.username`` is the handle/identifier
-  and ``login.password`` is the app password.
+  login (default ``"Bluesky"``). Its ``username`` is the handle/identifier and
+  its ``password`` is the app password.
 - ``BLUESKY_HANDLE`` -- optional override for the identifier if it isn't stored
   as the item's username.
 """
@@ -28,6 +40,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 
 DEFAULT_ITEM = "Bluesky"
 
@@ -36,11 +49,16 @@ class SecretError(RuntimeError):
     """The secret could not be read (CLI missing, vault locked, item absent)."""
 
 
-def _bw(*args: str) -> str:
+def _require_bw() -> None:
     if shutil.which("bw") is None:
         raise SecretError(
             "Bitwarden CLI ('bw') not found. Install it and run `bw login`."
         )
+
+
+def _bw(*args: str) -> str:
+    """Run a ``bw`` subcommand with output captured (so secrets never print)."""
+    _require_bw()
     proc = subprocess.run(
         ["bw", *args],
         capture_output=True,
@@ -51,28 +69,83 @@ def _bw(*args: str) -> str:
         err = (proc.stderr or proc.stdout).strip()
         hint = ""
         if "locked" in err.lower() or "logged in" in err.lower():
-            hint = (
-                "  Unlock first: export BW_SESSION=\"$(bw unlock --raw)\""
-            )
+            hint = '  Unlock first: export BW_SESSION="$(bw unlock --raw)"'
         raise SecretError(f"`bw {' '.join(args)}` failed: {err}{hint}")
     return proc.stdout
+
+
+def _vault_status() -> str:
+    """Return the vault status: ``unlocked`` | ``locked`` | ``unauthenticated``.
+
+    ``bw status`` prints a JSON blob to stdout in every state. Tolerate a notice
+    line prepended to it; if it's unreadable, treat the vault as locked and let
+    the unlock path take over.
+    """
+    _require_bw()
+    proc = subprocess.run(
+        ["bw", "status"], capture_output=True, text=True, env=os.environ
+    )
+    out = proc.stdout or ""
+    start = out.find("{")
+    if start == -1:
+        return "locked"
+    try:
+        data = json.loads(out[start:])
+    except json.JSONDecodeError:
+        return "locked"
+    return data.get("status", "locked")
+
+
+def _ensure_unlocked() -> None:
+    """Make sure the vault is usable for this process.
+
+    No-op if already unlocked. If locked and we're attached to a terminal, run
+    ``bw unlock`` interactively: the prompt is visible on stderr, the session
+    key is captured from stdout (never printed) and stored in the environment so
+    the following ``bw get`` calls authenticate. With no tty, raise the manual
+    hint rather than block on an invisible prompt.
+    """
+    status = _vault_status()
+    if status == "unlocked":
+        return
+    if status == "unauthenticated":
+        raise SecretError("Bitwarden is not logged in. Run `bw login` first.")
+
+    # status == "locked" (or unreadable, treated as locked).
+    if not sys.stdin.isatty():
+        raise SecretError(
+            "Bitwarden vault is locked. Unlock first: "
+            'export BW_SESSION="$(bw unlock --raw)"'
+        )
+
+    # Interactive unlock: stdout captured (the raw session key), stderr/stdin
+    # inherited so the master-password prompt shows and you can type it.
+    proc = subprocess.run(
+        ["bw", "unlock", "--raw"],
+        stdout=subprocess.PIPE,
+        text=True,
+        env=os.environ,
+    )
+    session = (proc.stdout or "").strip()
+    if proc.returncode != 0 or not session:
+        raise SecretError("Bitwarden unlock failed or was cancelled.")
+    os.environ["BW_SESSION"] = session
 
 
 def bluesky_credentials(item_ref: str | None = None) -> tuple[str, str]:
     """Return ``(identifier, app_password)`` for Bluesky from the vault.
 
-    Reads one Bitwarden item; the password is never returned to the shell,
-    logged, or printed -- only handed to the API client.
+    Reads two narrow values (``bw get username`` / ``bw get password``); the
+    password is never returned to the shell, logged, or printed -- only handed
+    to the API client.
     """
     item_ref = item_ref or os.environ.get("BLUESKY_BW_ITEM", DEFAULT_ITEM)
-    try:
-        item = json.loads(_bw("get", "item", item_ref))
-    except json.JSONDecodeError as exc:  # pragma: no cover - defensive
-        raise SecretError(f"`bw get item {item_ref}` did not return JSON.") from exc
+    _ensure_unlocked()
 
-    login = item.get("login") or {}
-    identifier = os.environ.get("BLUESKY_HANDLE") or login.get("username")
-    password = login.get("password")
+    password = _bw("get", "password", item_ref).strip()
+    identifier = os.environ.get("BLUESKY_HANDLE") or _bw(
+        "get", "username", item_ref
+    ).strip()
 
     if not identifier:
         raise SecretError(


### PR DESCRIPTION
## What & why

`/announce` failed with `bw get item Bluesky did not return JSON` even though `bw get password Bluesky` works in the vault. The Bitwarden boundary fetched the whole item and `json.loads`'d it; when bw's stdout isn't clean JSON (an update notice prepended, or a "more than one result" message), the `JSONDecodeError` path threw bw's *actual* output away and raised a blind error — and since output is captured (so the password never prints), there was nothing on screen to debug.

## Changes

- **`site_publish/secrets.py`** — replace `bw get item` + JSON parse with two narrow reads, `bw get username` / `bw get password`, that return the raw value. No JSON to choke on; bw's real error surfaces on failure via the existing non-zero-exit path.
- **Interactive unlock** — if the vault is locked and stdin is a tty, run `bw unlock` with the master-password prompt visible and the session key captured (never printed), stashed into the env for the `get` calls. No tty → fail with the manual-unlock hint instead of hanging on an invisible prompt. Removes the mandatory `export BW_SESSION=…` for interactive use.
- **Docs** — `.claude/commands/announce.md` §2 and the `CLAUDE.md` publishing-pipeline note updated to describe the get-password reads + interactive unlock.

## Delivered + Verified

- `import site_publish.secrets` clean; `_vault_status()` reads `locked` correctly with no session.
- `--dry-run` compose path unchanged (still prints text + facets, no Bitwarden touch).
- No-tty locked path raises `SecretError` with the manual-unlock hint — fails cleanly, does **not** hang.
- The live `bw get password` + interactive-unlock send paths require a real terminal + unlocked vault (Chris verifies on the actual announce).

🤖 Generated with [Claude Code](https://claude.com/claude-code)