### PR TITLE
feat(announce): link-card embed + correct bsky.app handle

### DIFF
--- a/.claude/commands/announce.md
+++ b/.claude/commands/announce.md
@@ -19,7 +19,11 @@ Run everything from the repo root (`~/vault/projects/ChrisKornaros.github.io`).
 Run: `uv run announce $ARGUMENTS --dry-run`
 
 - This composes the post and prints it plus the detected facets (clickable link
-  + any `#tags`). It does **not** touch Bitwarden or the network.
+  + any `#tags`). It does **not** touch Bitwarden or the network. On the real
+  send (not dry-run) it also attaches a **link card** — the page's OG
+  title/description and image (uploaded as a thumb blob) — so the post shows a
+  Substack preview, not just a bare link. The card degrades to nothing if the
+  OG data can't be fetched; the post still goes out.
 - For a blog draft the link comes from the draft's `substack:` frontmatter; for
   anything else pass `--url`. Override the whole text with `--text`, and add
   hashtags with `--tag` (lowercase, few).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,12 @@ A draft is the canonical source; the site `.qmd` is generated from it.
   ([.claude/commands/announce.md](.claude/commands/announce.md)) posts a short
   Bluesky update linking to a just-published post. `uv run announce <draft>
   [--url …] [--tag …] --dry-run` composes + previews (clickable link/hashtag
-  facets, no network); dropping `--dry-run` sends it. It's a **runtime action,
-  not a code change** — no branch/PR. The Bluesky **app password** is read at
+  facets, no network); dropping `--dry-run` sends it. On send it also attaches
+  an `app.bsky.embed.external` **link card** (the page's OG title/description +
+  the image uploaded as a thumb blob), degrading to no card if the OG data
+  isn't fetchable; the printed `bsky.app` URL uses the account's real handle
+  from the session, not the login identifier. It's a **runtime action, not a
+  code change** — no branch/PR. The Bluesky **app password** is read at
   run time from a Bitwarden item via the `bw` CLI through the single
   [site_publish/secrets.py](site_publish/secrets.py) boundary via two narrow
   reads (`bw get username` / `bw get password`); a locked vault is unlocked

--- a/site_publish/bluesky.py
+++ b/site_publish/bluesky.py
@@ -21,9 +21,18 @@ import re
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
+from html.parser import HTMLParser
 from typing import Any
 
 DEFAULT_SERVICE = "https://bsky.social"
+
+# A descriptive UA -- some hosts (Substack included) serve thin/blocked HTML to
+# the bare urllib default.
+_UA = "ChrisKornaros-site-publish/1.0 (+https://chriskornaros.github.io)"
+# Only read the head-ish portion of a page; OG tags live up top.
+_MAX_HTML_BYTES = 600_000
+# Bluesky caps a blob at ~1 MB; stay safely under so uploadBlob doesn't 413.
+_MAX_THUMB_BYTES = 976_560
 
 # Detected on the UTF-8 *bytes* so match offsets are byte offsets (what facets
 # need). Trailing punctuation is trimmed from links so a sentence-final URL
@@ -119,9 +128,13 @@ def create_post(
     text: str,
     *,
     langs: tuple[str, ...] = ("en",),
+    embed: dict[str, Any] | None = None,
     service: str = DEFAULT_SERVICE,
 ) -> dict[str, Any]:
-    """Create an ``app.bsky.feed.post`` record; returns the API response (uri, cid)."""
+    """Create an ``app.bsky.feed.post`` record; returns the API response (uri, cid).
+
+    Pass ``embed`` (e.g. from :func:`build_external_embed`) to attach a link card.
+    """
     record: dict[str, Any] = {
         "$type": "app.bsky.feed.post",
         "text": text,
@@ -131,6 +144,8 @@ def create_post(
     facets = detect_facets(text)
     if facets:
         record["facets"] = facets
+    if embed:
+        record["embed"] = embed
 
     return _post_json(
         f"{service}/xrpc/com.atproto.repo.createRecord",
@@ -141,6 +156,129 @@ def create_post(
         },
         token=session["accessJwt"],
     )
+
+
+class _OGParser(HTMLParser):
+    """Collect ``<meta property|name=… content=…>`` pairs (first wins)."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.props: dict[str, str] = {}
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag != "meta":
+            return
+        a = {k: v for k, v in attrs}
+        key = a.get("property") or a.get("name")
+        content = a.get("content")
+        if key and content and key not in self.props:
+            self.props[key] = content
+
+
+def _get(url: str, *, timeout: float = 10.0) -> tuple[bytes, str] | None:
+    """GET ``url`` with a real UA; return ``(body, content_type)`` or None."""
+    req = urllib.request.Request(url, headers={"User-Agent": _UA})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            ctype = resp.headers.get("Content-Type", "")
+            body = resp.read(_MAX_HTML_BYTES)
+    except (urllib.error.URLError, OSError):
+        return None
+    return body, ctype
+
+
+def fetch_external_card(url: str) -> dict[str, str] | None:
+    """Fetch a page's Open Graph card data.
+
+    Returns ``{"uri", "title", "description", "image_url"}`` (any of the last
+    three may be empty), or None if the page can't be fetched / isn't HTML.
+    """
+    got = _get(url)
+    if got is None:
+        return None
+    body, ctype = got
+    if "html" not in ctype.lower():
+        return None
+    text = body.decode("utf-8", "replace")
+    parser = _OGParser()
+    try:
+        parser.feed(text)
+    except Exception:  # pragma: no cover - defensive against malformed HTML
+        pass
+    p = parser.props
+    return {
+        "uri": url,
+        "title": p.get("og:title") or p.get("twitter:title") or "",
+        "description": p.get("og:description") or p.get("twitter:description") or "",
+        "image_url": p.get("og:image") or p.get("twitter:image") or "",
+    }
+
+
+def upload_blob(
+    session: dict[str, Any], data: bytes, mime: str, *, service: str = DEFAULT_SERVICE
+) -> dict[str, Any]:
+    """Upload raw bytes via ``com.atproto.repo.uploadBlob``; returns the response.
+
+    The blob ref the caller wants is ``response["blob"]``.
+    """
+    req = urllib.request.Request(
+        f"{service}/xrpc/com.atproto.repo.uploadBlob", data=data, method="POST"
+    )
+    req.add_header("Content-Type", mime or "application/octet-stream")
+    req.add_header("Authorization", f"Bearer {session['accessJwt']}")
+    try:
+        with urllib.request.urlopen(req) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", "replace")
+        raise BlueskyError(f"uploadBlob -> HTTP {exc.code}: {body}") from exc
+    except urllib.error.URLError as exc:
+        raise BlueskyError(f"uploadBlob unreachable: {exc.reason}") from exc
+
+
+def _thumb_blob(
+    session: dict[str, Any], image_url: str, *, service: str
+) -> dict[str, Any] | None:
+    """Download an OG image and upload it as a blob; None if anything's off.
+
+    Image problems never sink the post -- a card without a thumb still beats a
+    bare link.
+    """
+    got = _get(image_url)
+    if got is None:
+        return None
+    data, ctype = got
+    mime = ctype.split(";")[0].strip().lower()
+    if not data or len(data) > _MAX_THUMB_BYTES or not mime.startswith("image/"):
+        return None
+    try:
+        resp = upload_blob(session, data, mime, service=service)
+    except BlueskyError:
+        return None
+    return resp.get("blob")
+
+
+def build_external_embed(
+    session: dict[str, Any], url: str, *, service: str = DEFAULT_SERVICE
+) -> dict[str, Any] | None:
+    """Build an ``app.bsky.embed.external`` link card for ``url``.
+
+    Degrades gracefully: no usable card data -> None; image missing / too big /
+    upload fails -> a card with title + description but no thumbnail.
+    """
+    card = fetch_external_card(url)
+    if not card or not (card["title"] or card["description"]):
+        return None
+    external: dict[str, Any] = {
+        "uri": card["uri"],
+        "title": card["title"],
+        "description": card["description"],
+    }
+    if card["image_url"]:
+        thumb = _thumb_blob(session, card["image_url"], service=service)
+        if thumb:
+            external["thumb"] = thumb
+    return {"$type": "app.bsky.embed.external", "external": external}
 
 
 def post_web_url(handle: str, at_uri: str) -> str | None:

--- a/site_publish/cli.py
+++ b/site_publish/cli.py
@@ -154,8 +154,12 @@ def announce(argv: list[str] | None = None) -> int:
 
     from . import bluesky
 
+    # The link to card, when there is one: explicit --url wins, else the
+    # composed announcement's link. --text posts verbatim with no card.
+    link: str | None = None
     if args.text:
         text = args.text
+        link = args.url
     else:
         try:
             ann = _announce.compose(
@@ -166,6 +170,7 @@ def announce(argv: list[str] | None = None) -> int:
         except ValueError as exc:
             parser.error(str(exc))
         text = ann.text
+        link = ann.url
 
     if args.dry_run:
         import json
@@ -173,6 +178,9 @@ def announce(argv: list[str] | None = None) -> int:
         print(text)
         print("--- facets ---")
         print(json.dumps(bluesky.detect_facets(text), indent=2))
+        if link:
+            print(f"\n(link card: an external embed for {link} will be fetched "
+                  "at send time)")
         print("\n(dry run: nothing sent, Bitwarden not touched)")
         return 0
 
@@ -183,15 +191,23 @@ def announce(argv: list[str] | None = None) -> int:
     try:
         identifier, password = secrets.bluesky_credentials(args.item)
         session = bluesky.create_session(identifier, password)
-        resp = bluesky.create_post(session, text)
+        # The link card degrades to None on any fetch/upload trouble, so a
+        # flaky OG fetch never blocks the post itself.
+        embed = bluesky.build_external_embed(session, link) if link else None
+        resp = bluesky.create_post(session, text, embed=embed)
     except (SecretError, BlueskyError) as exc:
         print(f"  ✗ {exc}", file=sys.stderr)
         return 1
 
-    web = bluesky.post_web_url(identifier, resp.get("uri", ""))
-    print(f"  ✓ Posted to Bluesky as {identifier}")
+    # Use the account's real handle from the session for the bsky.app URL --
+    # the login identifier may be an email, which isn't a valid profile slug.
+    handle = session.get("handle") or identifier
+    web = bluesky.post_web_url(handle, resp.get("uri", ""))
+    print(f"  ✓ Posted to Bluesky as {handle}")
     if web:
         print(f"      {web}")
+    if link and embed is None:
+        print("      (note: no link card — the page's OG data wasn't fetchable)")
     return 0
 
 


### PR DESCRIPTION
Two fixes from live-send feedback on the `phone-sync` announce.

## 1. Wrong profile in the printed URL (bug)

`post_web_url` was handed the login **identifier** as the profile slug — which is an email (`chriskornaros@gmail.com`), not a valid Bluesky handle — so the printed `bsky.app` link 404'd. Now built from the session's real `handle` (`chriskornaros.bsky.social`), and that handle is what's reported on success.

## 2. No preview card, just a bare link (feature)

A link facet is only clickable text. Bluesky renders a preview card when the post carries an `app.bsky.embed.external` embed — the app builds one client-side on paste, but over the API you attach it yourself. Added:

- `fetch_external_card(url)` — pulls OG `title`/`description`/`image` (stdlib `HTMLParser`, real UA).
- `upload_blob(session, data, mime)` — `com.atproto.repo.uploadBlob` for the thumb.
- `build_external_embed(session, url)` — assembles the embed, uploading the OG image as `thumb`.
- `create_post(..., embed=...)` attaches it; the CLI builds the card from the announced link.

**Degrades gracefully:** no OG data → no card; image missing / >~1 MB / upload fails → card with title + description but no thumb. A flaky fetch never blocks the post.

## Delivered + Verified

- Imports clean; `--dry-run` unchanged except a note that a card will be fetched at send time.
- `fetch_external_card` against the live Substack post returns title + description + image URL.
- `build_external_embed` with bad auth degrades to a no-thumb card (image upload failure swallowed).
- Handle fix: URL/handle now sourced from `session["handle"]`, falling back to the identifier only if absent.
- Live send (real card render on the timeline) is Chris's to confirm on the next announce.

Docs synced: CLAUDE.md publishing-pipeline note + `.claude/commands/announce.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)